### PR TITLE
Upload test coverage to codecov.io in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
         run: |
           make lint
           make type-check
-      - name: Test
-        run: make test
 
+      - name: Test
+        run: make test-coverage
+
+      - name: Upload Test Coverage
+        uses: codecov/codecov-action@v1

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,7 @@ type-check:
 	pipenv run mypy $(SRC_DIR)
 
 test:
-	pipenv run pytest --cov=server/
+	pipenv run pytest --cov=./
 
+test-coverage:
+	pipenv run pytest --cov=./ --cov-report=xml


### PR DESCRIPTION
Denna PR ser till att en "coverage report" i XML genereras när testen körs i CI och laddas upp till [codecov.io](https://about.codecov.io/). Codecov.io ger en detaljerad överblick av vilka delar av kodbasen som täcks av test och vart test saknas.

I README filen kan vi exempelvis, visa en "badge" med hur många procent av kodbasen som täcks av test.

<img width="121" alt="Screenshot 2020-12-23 at 15 48 00" src="https://user-images.githubusercontent.com/43838780/103008988-4437f300-4536-11eb-98d3-e89394962776.png">