### PR TITLE
Scaffolding for sudoku package

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,8 @@
     "react": "16.13.1",
     "react-native": "0.63.4",
     "react-native-gesture-handler": "^1.10.3",
-    "react-native-reanimated": "^2.0.0"
+    "react-native-reanimated": "^2.0.0",
+    "sudoku-ts": "file:../sudoku"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/app/src/Playground.tsx
+++ b/app/src/Playground.tsx
@@ -1,0 +1,10 @@
+// Temporary file for trying stuff out
+
+import Sudoku from 'sudoku-ts';
+
+const sudoku = new Sudoku();
+
+sudoku.solve();
+sudoku.hint();
+sudoku.verify();
+sudoku.generate();

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -6514,6 +6514,9 @@ sudo-prompt@^9.0.0:
   resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-9.2.1.tgz#77efb84309c9ca489527a4e749f287e6bdd52afd"
   integrity sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==
 
+"sudoku-ts@file:../sudoku":
+  version "1.0.0"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"

--- a/sudoku/index.ts
+++ b/sudoku/index.ts
@@ -1,0 +1,3 @@
+import Sudoku from "./src/interface/sudoku"
+
+export default Sudoku

--- a/sudoku/package.json
+++ b/sudoku/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sudoku-ts",
+  "version": "1.0.0",
+  "main": "index.ts"
+}

--- a/sudoku/src/interface/sudoku.ts
+++ b/sudoku/src/interface/sudoku.ts
@@ -1,0 +1,17 @@
+export default class Sudoku {
+  public solve() {
+    console.log('Solves a sudoku')
+  }
+
+  public hint() {
+    console.log('Provides hints for a sudoku')
+  }
+
+  public verify() {
+    console.log('Verifies if sudoku is valid')
+  }
+
+  public generate() {
+    console.log('Generates new sudoku')
+  }
+}


### PR DESCRIPTION
Har skapat ett separate paket för kommande sudoku kod. Det verkar rätt rakt fram.

Tänker att vi har en klass som interface med metoder för `solve`, `hint`, `generate` osv. Har också installerat detta sudoku paket som dependency i React Native app koden.

Skapade en tillfällig `Playground` fil som demonstrerar att det funkar. Så i appen kan vi nu importera Sudoku klassen och använda dess metoder.

```javascript
import Sudoku from 'sudoku-ts'

const sudoku = new Sudoku()

sudoku.solve()
sudoku.hint()
sudoku.verify()
sudoku.generate()
```

Jag kallade paketet `sudoku-ts` för det verkar som att namnet måste vare unikt även fast vi inte publicerar till npm. Om jag exempelvis kallar det `sudoku` så installeras istället en annan sudoku dependency från npm. Vi kan alltid ändra namnet till något annat framöver.